### PR TITLE
Paho MQTT client subscribe-only is currently broken

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -15,6 +15,13 @@ func subscribe(c *cli.Context) {
 		log.Error(err)
 		os.Exit(1)
 	}
+
+	// Setting KeepAlive to 0 disables it. Paho MQTT client is currently broken
+	// and does not send ping when subscribing only.
+	// TODO set KeepAlive to a real value (60s?) when this change is merged:
+	// https://git.eclipse.org/r/#/c/65850/
+	opts.SetKeepAlive(time.Duration(0))
+
 	if c.Bool("c") {
 		clientId := c.String("i")
 		if clientId == "" {


### PR DESCRIPTION
setting the KeepAlive timeout to 0 prevents timeout disconnects.
Currently the Paho behavior is for subscribe-only clients to disconnect
every 30s

Hi @shirou! This is a problem I ran into writing the Telegraf MQTT input as well. The most recent revision of the Paho client sets the client keepalive to 30s but doesn't send pings properly, thus will disconnect every 30-45s