### PR TITLE
This is now fixed in the Paho client, setting timeout to 60s

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -15,12 +15,7 @@ func subscribe(c *cli.Context) {
 		log.Error(err)
 		os.Exit(1)
 	}
-
-	// Setting KeepAlive to 0 disables it. Paho MQTT client is currently broken
-	// and does not send ping when subscribing only.
-	// TODO set KeepAlive to a real value (60s?) when this change is merged:
-	// https://git.eclipse.org/r/#/c/65850/
-	opts.SetKeepAlive(time.Duration(0))
+	opts.SetKeepAlive(time.Second * 60)
 
 	if c.Bool("c") {
 		clientId := c.String("i")


### PR DESCRIPTION
Why 60s? This is the timeout I've generally seen used by MQTT client
UIs.