### PR TITLE
feat: remove h flag for help

### DIFF
--- a/config.go
+++ b/config.go
@@ -120,7 +120,7 @@ func getSettingsFromFile(confPath string, opts *MQTT.ClientOptions) error {
 			scheme = "ssl"
 		}
 		brokerUri := fmt.Sprintf("%s://%s:%d", scheme, ret.Host, ret.Port)
-		log.Infof("Broker URI: %s", brokerUri)
+		log.Infof("Broker URI(from config): %s", brokerUri)
 		opts.AddBroker(brokerUri)
 	}
 

--- a/main.go
+++ b/main.go
@@ -106,16 +106,21 @@ func main() {
 	app.Usage = usage
 	app.Version = version
 
+	cli.HelpFlag = &cli.BoolFlag{
+		Name:  "help",
+		Usage: usage,
+	}
+
 	commonFlags := []cli.Flag{
 		&cli.StringFlag{
-			Name:    "host",
-			Value:   "localhost",
-			Usage:   "mqtt host to connect to. Defaults to localhost",
+			Name:    "h,host",
+			Value:   "",
+			Usage:   "mqtt host to connect to. Defaults is localhost",
 			EnvVars: []string{"MQTT_HOST"}},
 		&cli.IntFlag{
 			Name:    "p, port",
 			Value:   1883,
-			Usage:   "network port to connect to. Defaults to 1883",
+			Usage:   "network port to connect to. Defaults is 1883",
 			EnvVars: []string{"MQTT_PORT"}},
 		&cli.StringFlag{
 			Name:    "u,user",

--- a/mqtt.go
+++ b/mqtt.go
@@ -30,7 +30,7 @@ func (m *MQTTClient) Connect() (MQTT.Client, error) {
 
 	m.Client = MQTT.NewClient(m.Opts)
 
-	log.Info("connecting...")
+	log.Infof("connecting...")
 
 	if token := m.Client.Connect(); token.Wait() && token.Error() != nil {
 		return nil, token.Error()
@@ -130,6 +130,10 @@ func NewOption(c *cli.Context) (*MQTT.ClientOptions, error) {
 	opts.SetClientID(clientId)
 
 	scheme := "tcp"
+	if port == 8883 {
+		scheme = "ssl"
+	}
+
 	cafile := c.String("cafile")
 	key := c.String("key")
 	cert := c.String("cert")
@@ -155,7 +159,10 @@ func NewOption(c *cli.Context) (*MQTT.ClientOptions, error) {
 		opts.SetPassword(password)
 	}
 
-	if host != "" {
+	if host == "" {
+		host = "localhost"
+	}
+	if len(opts.Servers) == 0 {
 		brokerUri := fmt.Sprintf("%s://%s:%d", scheme, host, port)
 		log.Infof("Broker URI: %s", brokerUri)
 


### PR DESCRIPTION
When I built mqttcli, https://github.com/urfave/cli did not have `HelpFlag` and could not override `-h` with host. So I had to explicitly specify host with `--host=""`.

I just remembered and checked, and found that we can override `-h` with `HelpFlag`, so I created this PR.

Now `--host=""` is not required.

```
./mqttcli sub -d -t "sometopic" --conf mqttcli.cfg
DEBU[0000] reading from config file: mqttcli.cfg
INFO[0000] Broker URI(from config): tcp://exampleserver:1883
INFO[0000] Topic: sometopic
INFO[0000] connecting...
```